### PR TITLE
added duplicate button for all/default store

### DIFF
--- a/app/code/community/Hackathon/MultistoreBlocks/Block/Adminhtml/Cms/Block/Edit.php
+++ b/app/code/community/Hackathon/MultistoreBlocks/Block/Adminhtml/Cms/Block/Edit.php
@@ -71,6 +71,14 @@ class Hackathon_MultistoreBlocks_Block_Adminhtml_Cms_Block_Edit extends Mage_Adm
                     'class'     => 'add',
                 ));
             }
+            $storeId = Mage_Core_Model_App::ADMIN_STORE_ID;
+            if ( ! in_array(0, $storeIdsWithThisBlock)) {
+                $this->_addButton('add_for_store_' . $storeId, array(
+                    'label'     => Mage::helper('adminhtml')->__('Duplicate block for %s', '"all store views"'),
+                    'onclick'   => 'setLocation(\'' . Mage::helper('adminhtml')->getUrl('adminhtml/cms_block/new', array('original_block_id' => $block->getId(), 'store_id' => $storeId)) .'\')',
+                    'class'     => 'add',
+                ));
+            }
         }
 
         /* For add screen */


### PR DESCRIPTION
If you first create blocks with specific languages and want to add a default language later, it is quite helpful if you can copy the block to the "all store views" store.
